### PR TITLE
Fix for newer dask

### DIFF
--- a/odvc/utils.py
+++ b/odvc/utils.py
@@ -7,7 +7,7 @@ from collections import OrderedDict
 import dask
 import dask.array as da
 
-from dask.async import get_sync
+from dask.local import get_sync
 
 import netCDF4
 


### PR DESCRIPTION
They dropped `async` b/c that became a builtin in newer Python versions.